### PR TITLE
Moving motor to pin 2; adding "check" that it's safe to send motor commands

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -25,6 +25,7 @@ monitor_speed = 115200
 lib_deps =
 	Wire
     https://github.com/gcl8a/linalg-micro
+    https://github.com/gcl8a/event_timer
 	https://github.com/adafruit/Adafruit_BusIO
 	https://github.com/WPIBotOnAWire/rosserial_arduino_lib#samd21
 	https://github.com/WPIBotOnAWire/Adafruit_INA260

--- a/src/esc-samd21.cpp
+++ b/src/esc-samd21.cpp
@@ -21,19 +21,19 @@ void ESCDirect::Init(void)
                      GCLK_GENCTRL_ID(4);          // Select GCLK4
   while (GCLK->STATUS.bit.SYNCBUSY);              // Wait for synchronization
 
-  // Enable the port multiplexer for digital pin 13 (D13; PA17): timer TCC0 output
-  PORT->Group[g_APinDescription[13].ulPort].PINCFG[g_APinDescription[13].ulPin].bit.PMUXEN = 1;
+//   // Enable the port multiplexer for digital pin 13 (D13; PA17): timer TCC0 output
+//   PORT->Group[g_APinDescription[13].ulPort].PINCFG[g_APinDescription[13].ulPin].bit.PMUXEN = 1;
   
-  // Connect the TCC0 timer to the port output - port pins are paired odd PMUXO and even PMUXE
-  // F & E specify the timers: TCC0, TCC1 and TCC2
-  PORT->Group[g_APinDescription[13].ulPort].PMUX[g_APinDescription[13].ulPin >> 1].reg = PORT_PMUX_PMUXO_F;
+//   // Connect the TCC0 timer to the port output - port pins are paired odd PMUXO and even PMUXE
+//   // F & E specify the timers: TCC0, TCC1 and TCC2
+//   PORT->Group[g_APinDescription[13].ulPort].PMUX[g_APinDescription[13].ulPin >> 1].reg = PORT_PMUX_PMUXO_F;
   
-  // Enable the port multiplexer for digital pin 10 (D10; PA18): timer TCC0 output
-  PORT->Group[g_APinDescription[10].ulPort].PINCFG[g_APinDescription[10].ulPin].bit.PMUXEN = 1;
+//   // Enable the port multiplexer for digital pin 10 (D10; PA18): timer TCC0 output
+//   PORT->Group[g_APinDescription[10].ulPort].PINCFG[g_APinDescription[10].ulPin].bit.PMUXEN = 1;
   
-  // Connect the TCC0 timer to the port output - port pins are paired odd PMUXO and even PMUXE
-  // F & E specify the timers: TCC0, TCC1 and TCC2
-  PORT->Group[g_APinDescription[10].ulPort].PMUX[g_APinDescription[10].ulPin >> 1].reg = PORT_PMUX_PMUXE_F;
+//   // Connect the TCC0 timer to the port output - port pins are paired odd PMUXO and even PMUXE
+//   // F & E specify the timers: TCC0, TCC1 and TCC2
+//   PORT->Group[g_APinDescription[10].ulPort].PMUX[g_APinDescription[10].ulPin >> 1].reg = PORT_PMUX_PMUXE_F;
   
   // Enable the port multiplexer for digital pin 2 (D2; PA14): timer TCC0 output
   PORT->Group[g_APinDescription[2].ulPort].PINCFG[g_APinDescription[2].ulPin].bit.PMUXEN = 1;
@@ -60,13 +60,17 @@ void ESCDirect::Init(void)
   REG_TCC0_PER = 20000;      // Set the frequency of the PWM on TCC0 to 50Hz
   while(TCC0->SYNCBUSY.bit.PER);
 
-  // The CCBx register value corresponds to the pulsewidth in microseconds (us)
-  REG_TCC0_CCB3 = oMid;       // TCC0 CCB3 - center the servo on D13
-  while(TCC0->SYNCBUSY.bit.CCB3);
+//   // The CCBx register value corresponds to the pulsewidth in microseconds (us)
+//   REG_TCC0_CCB3 = oMid;       // TCC0 CCB3 - center the servo on D13
+//   while(TCC0->SYNCBUSY.bit.CCB3);
+
+//   // The CCBx register value corresponds to the pulsewidth in microseconds (us)
+//   REG_TCC0_CCB2 = oMid;       // TCC0 CCB2 - center the servo on D10
+//   while(TCC0->SYNCBUSY.bit.CCB2);
 
   // The CCBx register value corresponds to the pulsewidth in microseconds (us)
-  REG_TCC0_CCB2 = oMid;       // TCC0 CCB0 - center the servo on D12
-  while(TCC0->SYNCBUSY.bit.CCB2);
+  REG_TCC0_CCB0 = oMid;       // TCC0 CCB0 - center the servo on D2
+  while(TCC0->SYNCBUSY.bit.CCB0);
 
   // Divide the 16MHz signal by 8 giving 2MHz (0.5us) TCC0 timer tick and enable the outputs
   REG_TCC0_CTRLA |= TCC_CTRLA_PRESCALER_DIV8 |    // Divide GCLK4 by 8
@@ -97,13 +101,17 @@ ESCDirect::MOTOR_STATE ESCDirect::Arm(void)
 
 void ESCDirect::WriteMicroseconds(uint16_t uSec)
 {
-    // The CCBx register value corresponds to the pulsewidth in microseconds (us)
-    REG_TCC0_CCB3 = uSec;       // TCC0 CCB3 - center the servo on D13
-    while(TCC0->SYNCBUSY.bit.CCB3);
+    // // The CCBx register value corresponds to the pulsewidth in microseconds (us)
+    // REG_TCC0_CCB3 = uSec;       // TCC0 CCB3 - center the servo on D13
+    // while(TCC0->SYNCBUSY.bit.CCB3);
+
+    // // The CCBx register value corresponds to the pulsewidth in microseconds (us)
+    // REG_TCC0_CCB2 = uSec;       // TCC0 CCB0 - center the servo on D12
+    // while(TCC0->SYNCBUSY.bit.CCB2);
 
     // The CCBx register value corresponds to the pulsewidth in microseconds (us)
-    REG_TCC0_CCB2 = uSec;       // TCC0 CCB0 - center the servo on D12
-    while(TCC0->SYNCBUSY.bit.CCB2);
+    REG_TCC0_CCB0 = uSec;       // TCC0 CCB0 - center the servo on D12
+    while(TCC0->SYNCBUSY.bit.CCB0);
 }
 
 /*

--- a/src/esc-samd21.h
+++ b/src/esc-samd21.h
@@ -3,28 +3,48 @@
 #include <Arduino.h>
 #include <event_timer.h>
 
+// Motor Constants -- TODO: pass to constructor
+// fullforward = 2000, fullback = 1000
+#define MOTOR_FULL_REV    1000
+#define MOTOR_STOP        1500
+#define MOTOR_FULL_FWD    2000
+
+/**
+ * There is some confusion about how the ESCs are set up. The datasheet has
+ * lots of options for calibrating, but it appears they have a fixed calibration range (1000 - 2000us).
+ * 
+ * Experiments show that you only have to set the signal to 1500us for a 
+ * 'few moments' and it beep-a-leeps at you.
+ * 
+ * So, we'll remove the Calibration function and just default to 1500us
+ * in the Init() function. Then we'll need a timestamp for checking if it's
+ * armed and call it good.
+ */
+
 class ESCDirect
 {
+public:
+    enum MOTOR_STATE {IDLE, ARMED};
+
 private:
-    enum MOTOR_STATE {IDLE, AMRING, CAL_LOW, CAL_HIGH, STOPPED, ACTIVE};
     MOTOR_STATE motorState = IDLE;
+    EventTimer motorTimer;
 
     // Calibration
-    int oMin = 1000; 
-    int oMid = 1500;
-    int oStop = 1500;
-    int oMax = 2000;
-    int oArm = 500;
+    int oMin = MOTOR_FULL_REV; 
+    int oMid = MOTOR_STOP;
+    int oStop = MOTOR_STOP;
+    int oMax = MOTOR_FULL_FWD;
 
-    uint32_t calibrationDelay = 3000;	// Calibration delay (millisecond)
+    uint32_t armingDelay = 3000;	// Calibration delay (millisecond)
 
     void WriteMicroseconds(uint16_t uSec);
-    void WriteMin(uint32_t duration) {}
 
 public:
     void Init(void);
-    void Arm(void);
+    MOTOR_STATE Arm(void);
+    bool isArmed(void) {return motorState == ARMED;}
+    
+    MOTOR_STATE SetSpeed(int16_t pct);
     void Stop(void) {WriteMicroseconds(oStop);}
-    void SetSpeed(int16_t pct);
-    void Calibrate(void);
 };

--- a/src/esc-samd21.h
+++ b/src/esc-samd21.h
@@ -1,10 +1,14 @@
 #pragma once
 
 #include <Arduino.h>
+#include <event_timer.h>
 
 class ESCDirect
 {
 private:
+    enum MOTOR_STATE {IDLE, AMRING, CAL_LOW, CAL_HIGH, STOPPED, ACTIVE};
+    MOTOR_STATE motorState = IDLE;
+
     // Calibration
     int oMin = 1000; 
     int oMid = 1500;
@@ -12,9 +16,10 @@ private:
     int oMax = 2000;
     int oArm = 500;
 
-    uint32_t calibrationDelay = 8000;	// Calibration delay (millisecond)
+    uint32_t calibrationDelay = 3000;	// Calibration delay (millisecond)
 
     void WriteMicroseconds(uint16_t uSec);
+    void WriteMin(uint32_t duration) {}
 
 public:
     void Init(void);


### PR DESCRIPTION
For motor commands, there are now IDLE and ARMED states. The logic is trivial -- after five seconds, the state can move to ARMED. The timer defaults to sending a neutral (1500us) pulse -- if that is sent for 5 seconds, that's plenty of time to initialize the ESCs. The user will have to check the state and arm it, if needed (after 5 seconds).